### PR TITLE
Added necessary copy commands to move pem files to right directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,7 @@ FROM alpine:latest
 RUN apk update && apk upgrade && apk add openssl freeradius 
 COPY --chown=radius:radius radiusd.conf /etc/raddb/radiusd.conf
 COPY --chown=radius:radius cacerts/ /etc/raddb/cacerts
+COPY --chown=radius:radius key.pem /etc/raddb/key.pem
+COPY --chown=radius:radius cert.pem /etc/raddb/cert.pem
 EXPOSE 1812:1812/udp 1812:1813/udp 
 CMD ["/usr/sbin/radiusd","-f","-lstdout"]


### PR DESCRIPTION
FYI, We had to add the extra COPY commands in Dockerfile.  Without these, the `docker run -v` stuff mounts empty directories instead of the proper PEM files.